### PR TITLE
Add quote_type in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ trim_trailing_whitespace = true
 [{*.js,*.mjs,*.ts,*.json,*.yml}]
 indent_size = 2
 indent_style = space
+
+[{*.js,*.mjs,*.ts}]
+quote_type = single


### PR DESCRIPTION
Motivation: make it available to work/play with code examples without any changes in IDE to any student.
Issue: 
`eslintrc.json` has
  ```
"quotes": [
       "error",
       single
     ]
```
And prettier by default puts double quotes when parsing `.editorconfig` .
**So, the code formatter conflicts with the linter.**