### PR TITLE
Add check if module has callable signature

### DIFF
--- a/JavaScript/0-complex/application.js
+++ b/JavaScript/0-complex/application.js
@@ -13,7 +13,9 @@ require('./lib/unit3')(api, application);
 application.reloadUnit = (name) => {
   const moduleKey = require.resolve('./lib/' + name);
   delete require.cache[moduleKey];
-  require('./lib/' + name)(api, application);
+  
+  const module = require('./lib/' + name)
+  typeof module === 'function' && module(api, application); 
 };
 
 application.startWatching = () => {

--- a/JavaScript/0-complex/application.js
+++ b/JavaScript/0-complex/application.js
@@ -13,9 +13,8 @@ require('./lib/unit3')(api, application);
 application.reloadUnit = (name) => {
   const moduleKey = require.resolve('./lib/' + name);
   delete require.cache[moduleKey];
-  
-  const module = require('./lib/' + name)
-  typeof module === 'function' && module(api, application); 
+  const module = require('./lib/' + name);
+  if (typeof module === 'function') module(api, application);
 };
 
 application.startWatching = () => {


### PR DESCRIPTION
If the module hasn't a callable signature will throw the error `require('./lib/' + name)(...)` is not a function.